### PR TITLE
fix: 代码质量修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/
+*.exe
+*.o
+*.out
+.vscode/tasks.json

--- a/KArcCache/KArcCache.h
+++ b/KArcCache/KArcCache.h
@@ -21,7 +21,7 @@ public:
 
     ~KArcCache() override = default;
 
-    void put(Key key, Value value) override 
+    void put(const Key& key, const Value& value) override
     {
         checkGhostCaches(key);
 
@@ -36,7 +36,7 @@ public:
         }
     }
 
-    bool get(Key key, Value& value) override 
+    bool get(const Key& key, Value& value) override
     {
         checkGhostCaches(key);
 
@@ -52,7 +52,7 @@ public:
         return lfuPart_->get(key, value);
     }
 
-    Value get(Key key) override 
+    Value get(const Key& key) override
     {
         Value value{};
         get(key, value);
@@ -60,7 +60,7 @@ public:
     }
 
 private:
-    bool checkGhostCaches(Key key) 
+    bool checkGhostCaches(const Key& key)
     {
         bool inGhost = false;
         if (lruPart_->checkGhost(key)) 

--- a/KArcCache/KArcLfuPart.h
+++ b/KArcCache/KArcLfuPart.h
@@ -26,7 +26,7 @@ public:
         initializeLists();
     }
 
-    bool put(Key key, Value value) 
+    bool put(const Key& key, const Value& value)
     {
         if (capacity_ == 0) 
             return false;
@@ -40,7 +40,7 @@ public:
         return addNewNode(key, value);
     }
 
-    bool get(Key key, Value& value) 
+    bool get(const Key& key, Value& value)
     {
         std::lock_guard<std::mutex> lock(mutex_);
         auto it = mainCache_.find(key);
@@ -53,12 +53,13 @@ public:
         return false;
     }
 
-    bool contain(Key key)
+    bool contain(const Key& key)
     {
+        std::lock_guard<std::mutex> lock(mutex_);
         return mainCache_.find(key) != mainCache_.end();
     }
 
-    bool checkGhost(Key key) 
+    bool checkGhost(const Key& key)
     {
         auto it = ghostCache_.find(key);
         if (it != ghostCache_.end()) 

--- a/KArcCache/KArcLruPart.h
+++ b/KArcCache/KArcLruPart.h
@@ -23,7 +23,7 @@ public:
         initializeLists();
     }
 
-    bool put(Key key, Value value) 
+    bool put(const Key& key, const Value& value)
     {
         if (capacity_ == 0) return false;
         
@@ -36,7 +36,7 @@ public:
         return addNewNode(key, value);
     }
 
-    bool get(Key key, Value& value, bool& shouldTransform) 
+    bool get(const Key& key, Value& value, bool& shouldTransform)
     {
         std::lock_guard<std::mutex> lock(mutex_);
         auto it = mainCache_.find(key);
@@ -49,7 +49,7 @@ public:
         return false;
     }
 
-    bool checkGhost(Key key) 
+    bool checkGhost(const Key& key)
     {
         auto it = ghostCache_.find(key);
         if (it != ghostCache_.end()) {

--- a/KICachePolicy.h
+++ b/KICachePolicy.h
@@ -10,12 +10,12 @@ public:
     virtual ~KICachePolicy() {};
 
     // 添加缓存接口
-    virtual void put(Key key, Value value) = 0;
+    virtual void put(const Key& key, const Value& value) = 0;
 
     // key是传入参数  访问到的值以传出参数的形式返回 | 访问成功返回true
-    virtual bool get(Key key, Value& value) = 0;
+    virtual bool get(const Key& key, Value& value) = 0;
     // 如果缓存中能找到key，则直接返回value
-    virtual Value get(Key key) = 0;
+    virtual Value get(const Key& key) = 0;
 
 };
 

--- a/KLfuCache.h
+++ b/KLfuCache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -26,9 +27,9 @@ private:
         std::weak_ptr<Node> pre; // 上一结点改为weak_ptr打破循环引用
         std::shared_ptr<Node> next;
 
-        Node() 
+        Node()
         : freq(1), next(nullptr) {}
-        Node(Key key, Value value) 
+        Node(const Key& key, const Value& value)
         : freq(1), key(key), value(value), next(nullptr) {}
     };
 
@@ -91,13 +92,13 @@ public:
     using NodeMap = std::unordered_map<Key, NodePtr>;
 
     KLfuCache(int capacity, int maxAverageNum = 1000000)
-    : capacity_(capacity), minFreq_(INT8_MAX), maxAverageNum_(maxAverageNum),
+    : capacity_(capacity), minFreq_(std::numeric_limits<int>::max()), maxAverageNum_(maxAverageNum),
       curAverageNum_(0), curTotalNum_(0) 
     {}
 
     ~KLfuCache() override = default;
 
-    void put(Key key, Value value) override
+    void put(const Key& key, const Value& value) override
     {
         if (capacity_ == 0)
             return;
@@ -108,8 +109,9 @@ public:
         {
             // 重置其value值
             it->second->value = value;
-            // 找到了直接调整就好了，不用再去get中再找一遍，但其实影响不大
-            getInternal(it->second, value);
+            // 更新访问频率，原value已更新无需返回
+            Value unused;
+            getInternal(it->second, unused);
             return;
         }
 
@@ -117,7 +119,7 @@ public:
     }
 
     // value值为传出参数
-    bool get(Key key, Value& value) override
+    bool get(const Key& key, Value& value) override
     {
       std::lock_guard<std::mutex> lock(mutex_);
       auto it = nodeMap_.find(key);
@@ -130,7 +132,7 @@ public:
       return false;
     }
 
-    Value get(Key key) override
+    Value get(const Key& key) override
     {
       Value value;
       get(key, value);
@@ -145,7 +147,7 @@ public:
     }
 
 private:
-    void putInternal(Key key, Value value); // 添加缓存
+    void putInternal(const Key& key, const Value& value); // 添加缓存
     void getInternal(NodePtr node, Value& value); // 获取缓存
 
     void kickOut(); // 移除缓存中的过期数据
@@ -166,7 +168,7 @@ private:
     int                                            curTotalNum_; // 当前访问所有缓存次数总数 
     std::mutex                                     mutex_; // 互斥锁
     NodeMap                                        nodeMap_; // key 到 缓存节点的映射
-    std::unordered_map<int, FreqList<Key, Value>*> freqToFreqList_;// 访问频次到该频次链表的映射
+    std::unordered_map<int, std::unique_ptr<FreqList<Key, Value>>> freqToFreqList_;// 访问频次到该频次链表的映射
 };
 
 template<typename Key, typename Value>
@@ -189,7 +191,7 @@ void KLfuCache<Key, Value>::getInternal(NodePtr node, Value& value)
 }
 
 template<typename Key, typename Value>
-void KLfuCache<Key, Value>::putInternal(Key key, Value value)
+void KLfuCache<Key, Value>::putInternal(const Key& key, const Value& value)
 {   
     // 如果不在缓存中，则需要判断缓存是否已满
     if (nodeMap_.size() == capacity_)
@@ -238,7 +240,7 @@ void KLfuCache<Key, Value>::addToFreqList(NodePtr node)
     if (freqToFreqList_.find(node->freq) == freqToFreqList_.end())
     {
         // 不存在则创建
-        freqToFreqList_[node->freq] = new FreqList<Key, Value>(node->freq);
+        freqToFreqList_[node->freq] = std::make_unique<FreqList<Key, Value>>(node->freq);
     }
 
     freqToFreqList_[freq]->addNode(node);
@@ -311,7 +313,7 @@ void KLfuCache<Key, Value>::handleOverMaxAverageNum()
 template<typename Key, typename Value>
 void KLfuCache<Key, Value>::updateMinFreq() 
 {
-    minFreq_ = INT8_MAX;
+    minFreq_ = std::numeric_limits<int>::max();
     for (const auto& pair : freqToFreqList_) 
     {
         if (pair.second && !pair.second->isEmpty()) 
@@ -319,7 +321,7 @@ void KLfuCache<Key, Value>::updateMinFreq()
             minFreq_ = std::min(minFreq_, pair.first);
         }
     }
-    if (minFreq_ == INT8_MAX) 
+    if (minFreq_ == std::numeric_limits<int>::max())
         minFreq_ = 1;
 }
 
@@ -339,21 +341,21 @@ public:
         }
     }
 
-    void put(Key key, Value value)
+    void put(const Key& key, const Value& value)
     {
         // 根据key找出对应的lfu分片
         size_t sliceIndex = Hash(key) % sliceNum_;
         lfuSliceCaches_[sliceIndex]->put(key, value);
     }
 
-    bool get(Key key, Value& value)
+    bool get(const Key& key, Value& value)
     {
         // 根据key找出对应的lfu分片
         size_t sliceIndex = Hash(key) % sliceNum_;
         return lfuSliceCaches_[sliceIndex]->get(key, value);
     }
 
-    Value get(Key key)
+    Value get(const Key& key)
     {
         Value value;
         get(key, value);
@@ -371,7 +373,7 @@ public:
 
 private:
     // 将key计算成对应哈希值
-    size_t Hash(Key key)
+    size_t Hash(const Key& key)
     {
         std::hash<Key> hashFunc;
         return hashFunc(key);

--- a/KLruCache.h
+++ b/KLruCache.h
@@ -59,7 +59,7 @@ public:
     ~KLruCache() override = default;
 
     // 添加缓存
-    void put(Key key, Value value) override
+    void put(const Key& key, const Value& value) override
     {
         if (capacity_ <= 0)
             return;
@@ -76,7 +76,7 @@ public:
         addNewNode(key, value);
     }
 
-    bool get(Key key, Value& value) override
+    bool get(const Key& key, Value& value) override
     {
         std::lock_guard<std::mutex> lock(mutex_);
         auto it = nodeMap_.find(key);
@@ -89,7 +89,7 @@ public:
         return false;
     }
 
-    Value get(Key key) override
+    Value get(const Key& key) override
     {
         Value value{};
         // memset(&value, 0, sizeof(value));   // memset 是按字节设置内存的，对于复杂类型（如 string）使用 memset 可能会破坏对象的内部结构
@@ -98,7 +98,7 @@ public:
     }
 
     // 删除指定元素
-    void remove(Key key) 
+    void remove(const Key& key)
     {   
         std::lock_guard<std::mutex> lock(mutex_);
         auto it = nodeMap_.find(key);
@@ -187,12 +187,14 @@ class KLruKCache : public KLruCache<Key, Value>
 public:
     KLruKCache(int capacity, int historyCapacity, int k)
         : KLruCache<Key, Value>(capacity) // 调用基类构造
-        , historyList_(std::make_unique<KLruCache<Key, size_t>>(historyCapacity))
         , k_(k)
+        , historyList_(std::make_unique<KLruCache<Key, size_t>>(historyCapacity))
     {}
 
-    Value get(Key key) 
+    Value get(const Key& key)
     {
+        std::lock_guard<std::mutex> lock(kMutex_);
+
         // 首先尝试从主缓存获取数据
         Value value{};
         bool inMainCache = KLruCache<Key, Value>::get(key, value);
@@ -234,8 +236,10 @@ public:
         return value;
     }
 
-    void put(Key key, Value value) 
+    void put(const Key& key, const Value& value)
     {
+        std::lock_guard<std::mutex> lock(kMutex_);
+
         // 检查是否已在主缓存
         Value existingValue{};
         bool inMainCache = KLruCache<Key, Value>::get(key, existingValue);
@@ -267,6 +271,7 @@ public:
 
 private:
     int                                     k_; // 进入缓存队列的评判标准
+    mutable std::mutex                      kMutex_; // KLruKCache 互斥锁
     std::unique_ptr<KLruCache<Key, size_t>> historyList_; // 访问数据历史记录(value为访问次数)
     std::unordered_map<Key, Value>          historyValueMap_; // 存储未达到k次访问的数据值
 };
@@ -287,31 +292,30 @@ public:
         }
     }
 
-    void put(Key key, Value value)
+    void put(const Key& key, const Value& value)
     {
         // 获取key的hash值，并计算出对应的分片索引
         size_t sliceIndex = Hash(key) % sliceNum_;
         lruSliceCaches_[sliceIndex]->put(key, value);
     }
 
-    bool get(Key key, Value& value)
+    bool get(const Key& key, Value& value)
     {
         // 获取key的hash值，并计算出对应的分片索引
         size_t sliceIndex = Hash(key) % sliceNum_;
         return lruSliceCaches_[sliceIndex]->get(key, value);
     }
 
-    Value get(Key key)
+    Value get(const Key& key)
     {
-        Value value;
-        memset(&value, 0, sizeof(value));
+        Value value{};
         get(key, value);
         return value;
     }
 
 private:
     // 将key转换为对应hash值
-    size_t Hash(Key key)
+    size_t Hash(const Key& key)
     {
         std::hash<Key> hashFunc;
         return hashFunc(key);

--- a/testAllCachePolicy.cpp
+++ b/testAllCachePolicy.cpp
@@ -5,8 +5,12 @@
 #include <iomanip>
 #include <random>
 #include <algorithm>
-#include<array>
+#include <array>
 #include "KICachePolicy.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #include "KLfuCache.h"
 #include "KLruCache.h"
 #include "KArcCache/KArcCache.h"
@@ -14,7 +18,7 @@
 class Timer {
 public:
     Timer() : start_(std::chrono::high_resolution_clock::now()) {}
-    
+
     double elapsed() {
         auto now = std::chrono::high_resolution_clock::now();
         return std::chrono::duration_cast<std::chrono::milliseconds>(now - start_).count();
@@ -24,116 +28,121 @@ private:
     std::chrono::time_point<std::chrono::high_resolution_clock> start_;
 };
 
+struct Operation {
+    int key;
+    bool isPut;
+};
+
 // 辅助函数：打印结果
-void printResults(const std::string& testName, int capacity, 
-                 const std::vector<int>& get_operations, 
-                 const std::vector<int>& hits) {
+void printResults(const std::string& testName, int capacity,
+                  const std::vector<std::string>& names,
+                  const std::vector<int>& get_operations,
+                  const std::vector<int>& hits) {
     std::cout << "=== " << testName << " 结果汇总 ===" << std::endl;
     std::cout << "缓存大小: " << capacity << std::endl;
-    
-    // 假设对应的算法名称已在测试函数中定义
-    std::vector<std::string> names;
-    if (hits.size() == 3) {
-        names = {"LRU", "LFU", "ARC"};
-    } else if (hits.size() == 4) {
-        names = {"LRU", "LFU", "ARC", "LRU-K"};
-    } else if (hits.size() == 5) {
-        names = {"LRU", "LFU", "ARC", "LRU-K", "LFU-Aging"};
-    }
-    
+
     for (size_t i = 0; i < hits.size(); ++i) {
         double hitRate = 100.0 * hits[i] / get_operations[i];
-        std::cout << (i < names.size() ? names[i] : "Algorithm " + std::to_string(i+1)) 
-                  << " - 命中率: " << std::fixed << std::setprecision(2) 
+        std::cout << (i < names.size() ? names[i] : "Algorithm " + std::to_string(i + 1))
+                  << " - 命中率: " << std::fixed << std::setprecision(2)
                   << hitRate << "% ";
-        // 添加具体命中次数和总操作次数
         std::cout << "(" << hits[i] << "/" << get_operations[i] << ")" << std::endl;
     }
-    
-    std::cout << std::endl;  // 添加空行，使输出更清晰
+
+    std::cout << std::endl;
 }
 
 void testHotDataAccess() {
     std::cout << "\n=== 测试场景1：热点数据访问测试 ===" << std::endl;
-    
-    const int CAPACITY = 20;         // 缓存容量
-    const int OPERATIONS = 500000;   // 总操作次数
-    const int HOT_KEYS = 20;         // 热点数据数量
-    const int COLD_KEYS = 5000;      // 冷数据数量
-    
+
+    const int CAPACITY = 20;
+    const int OPERATIONS = 500000;
+    const int HOT_KEYS = 20;
+    const int COLD_KEYS = 5000;
+    const int SEED = 42;  // 固定种子，确保每次运行结果可复现
+
+    // 预生成操作序列，所有算法共用同一序列保证公平对比
+    std::vector<Operation> ops;
+    ops.reserve(OPERATIONS);
+    std::mt19937 gen(SEED);
+    for (int op = 0; op < OPERATIONS; ++op) {
+        bool isPut = (gen() % 100 < 30);
+        int key;
+        if (gen() % 100 < 70) {
+            key = gen() % HOT_KEYS;
+        } else {
+            key = HOT_KEYS + (gen() % COLD_KEYS);
+        }
+        ops.push_back({key, isPut});
+    }
+
     KamaCache::KLruCache<int, std::string> lru(CAPACITY);
     KamaCache::KLfuCache<int, std::string> lfu(CAPACITY);
     KamaCache::KArcCache<int, std::string> arc(CAPACITY);
-    // 为LRU-K设置合适的参数：
-    // - 主缓存容量与其他算法相同
-    // - 历史记录容量设为可能访问的所有键数量
-    // - k=2表示数据被访问2次后才会进入缓存，适合区分热点和冷数据
     KamaCache::KLruKCache<int, std::string> lruk(CAPACITY, HOT_KEYS + COLD_KEYS, 2);
     KamaCache::KLfuCache<int, std::string> lfuAging(CAPACITY, 20000);
 
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    
-    // 基类指针指向派生类对象，添加LFU-Aging
     std::array<KamaCache::KICachePolicy<int, std::string>*, 5> caches = {&lru, &lfu, &arc, &lruk, &lfuAging};
     std::vector<int> hits(5, 0);
     std::vector<int> get_operations(5, 0);
     std::vector<std::string> names = {"LRU", "LFU", "ARC", "LRU-K", "LFU-Aging"};
 
-    // 为所有的缓存对象进行相同的操作序列测试
-    for (int i = 0; i < caches.size(); ++i) {
-        // 先预热缓存，插入一些数据
+    // 所有缓存重放相同的操作序列
+    for (size_t i = 0; i < caches.size(); ++i) {
+        // 预热：插入热点数据
         for (int key = 0; key < HOT_KEYS; ++key) {
-            std::string value = "value" + std::to_string(key);
-            caches[i]->put(key, value);
+            caches[i]->put(key, "value" + std::to_string(key));
         }
-        
-        // 交替进行put和get操作，模拟真实场景
-        for (int op = 0; op < OPERATIONS; ++op) {
-            // 大多数缓存系统中读操作比写操作频繁
-            // 所以设置30%概率进行写操作
-            bool isPut = (gen() % 100 < 30); 
-            int key;
-            
-            // 70%概率访问热点数据，30%概率访问冷数据
-            if (gen() % 100 < 70) {
-                key = gen() % HOT_KEYS; // 热点数据
+
+        // 重放操作序列
+        for (size_t opIdx = 0; opIdx < ops.size(); ++opIdx) {
+            const auto& op = ops[opIdx];
+            if (op.isPut) {
+                std::string value = "value" + std::to_string(op.key) + "_v" + std::to_string(opIdx % 100);
+                caches[i]->put(op.key, value);
             } else {
-                key = HOT_KEYS + (gen() % COLD_KEYS); // 冷数据
-            }
-            
-            if (isPut) {
-                // 执行put操作
-                std::string value = "value" + std::to_string(key) + "_v" + std::to_string(op % 100);
-                caches[i]->put(key, value);
-            } else {
-                // 执行get操作并记录命中情况
                 std::string result;
                 get_operations[i]++;
-                if (caches[i]->get(key, result)) {
+                if (caches[i]->get(op.key, result)) {
                     hits[i]++;
                 }
             }
         }
     }
 
-    // 打印测试结果
-    printResults("热点数据访问测试", CAPACITY, get_operations, hits);
+    printResults("热点数据访问测试", CAPACITY, names, get_operations, hits);
 }
 
 void testLoopPattern() {
     std::cout << "\n=== 测试场景2：循环扫描测试 ===" << std::endl;
-    
-    const int CAPACITY = 50;          // 缓存容量
-    const int LOOP_SIZE = 500;        // 循环范围大小
-    const int OPERATIONS = 200000;    // 总操作次数
-    
+
+    const int CAPACITY = 50;
+    const int LOOP_SIZE = 500;
+    const int OPERATIONS = 200000;
+    const int SEED = 42;
+
+    // 预生成操作序列
+    std::vector<Operation> ops;
+    ops.reserve(OPERATIONS);
+    std::mt19937 gen(SEED);
+    int current_pos = 0;
+    for (int op = 0; op < OPERATIONS; ++op) {
+        bool isPut = (gen() % 100 < 20);
+        int key;
+        if (op % 100 < 60) {
+            key = current_pos;
+            current_pos = (current_pos + 1) % LOOP_SIZE;
+        } else if (op % 100 < 90) {
+            key = gen() % LOOP_SIZE;
+        } else {
+            key = LOOP_SIZE + (gen() % LOOP_SIZE);
+        }
+        ops.push_back({key, isPut});
+    }
+
     KamaCache::KLruCache<int, std::string> lru(CAPACITY);
     KamaCache::KLfuCache<int, std::string> lfu(CAPACITY);
     KamaCache::KArcCache<int, std::string> arc(CAPACITY);
-    // 为LRU-K设置合适的参数：
-    // - 历史记录容量设为总循环大小的两倍，覆盖范围内和范围外的数据
-    // - k=2，对于循环访问，这是一个合理的阈值
     KamaCache::KLruKCache<int, std::string> lruk(CAPACITY, LOOP_SIZE * 2, 2);
     KamaCache::KLfuCache<int, std::string> lfuAging(CAPACITY, 3000);
 
@@ -142,143 +151,123 @@ void testLoopPattern() {
     std::vector<int> get_operations(5, 0);
     std::vector<std::string> names = {"LRU", "LFU", "ARC", "LRU-K", "LFU-Aging"};
 
-    std::random_device rd;
-    std::mt19937 gen(rd());
-
-    // 为每种缓存算法运行相同的测试
-    for (int i = 0; i < caches.size(); ++i) {
-        // 先预热一部分数据（只加载20%的数据）
+    for (size_t i = 0; i < caches.size(); ++i) {
+        // 预热：加载20%的数据
         for (int key = 0; key < LOOP_SIZE / 5; ++key) {
-            std::string value = "loop" + std::to_string(key);
-            caches[i]->put(key, value);
+            caches[i]->put(key, "loop" + std::to_string(key));
         }
-        
-        // 设置循环扫描的当前位置
-        int current_pos = 0;
-        
-        // 交替进行读写操作，模拟真实场景
-        for (int op = 0; op < OPERATIONS; ++op) {
-            // 20%概率是写操作，80%概率是读操作
-            bool isPut = (gen() % 100 < 20);
-            int key;
-            
-            // 按照不同模式选择键
-            if (op % 100 < 60) {  // 60%顺序扫描
-                key = current_pos;
-                current_pos = (current_pos + 1) % LOOP_SIZE;
-            } else if (op % 100 < 90) {  // 30%随机跳跃
-                key = gen() % LOOP_SIZE;
-            } else {  // 10%访问范围外数据
-                key = LOOP_SIZE + (gen() % LOOP_SIZE);
-            }
-            
-            if (isPut) {
-                // 执行put操作，更新数据
-                std::string value = "loop" + std::to_string(key) + "_v" + std::to_string(op % 100);
-                caches[i]->put(key, value);
+
+        // 重放操作序列
+        for (size_t opIdx = 0; opIdx < ops.size(); ++opIdx) {
+            const auto& op = ops[opIdx];
+            if (op.isPut) {
+                std::string value = "loop" + std::to_string(op.key) + "_v" + std::to_string(opIdx % 100);
+                caches[i]->put(op.key, value);
             } else {
-                // 执行get操作并记录命中情况
                 std::string result;
                 get_operations[i]++;
-                if (caches[i]->get(key, result)) {
+                if (caches[i]->get(op.key, result)) {
                     hits[i]++;
                 }
             }
         }
     }
 
-    printResults("循环扫描测试", CAPACITY, get_operations, hits);
+    printResults("循环扫描测试", CAPACITY, names, get_operations, hits);
 }
 
 void testWorkloadShift() {
     std::cout << "\n=== 测试场景3：工作负载剧烈变化测试 ===" << std::endl;
-    
-    const int CAPACITY = 30;            // 缓存容量
-    const int OPERATIONS = 80000;       // 总操作次数
-    const int PHASE_LENGTH = OPERATIONS / 5;  // 每个阶段的长度
-    
+
+    const int CAPACITY = 30;
+    const int OPERATIONS = 80000;
+    const int PHASE_LENGTH = OPERATIONS / 5;
+    const int SEED = 42;
+
+    // 预生成操作序列
+    std::vector<Operation> ops;
+    ops.reserve(OPERATIONS);
+    std::mt19937 gen(SEED);
+    for (int op = 0; op < OPERATIONS; ++op) {
+        int phase = op / PHASE_LENGTH;
+
+        int putProbability;
+        switch (phase) {
+            case 0: putProbability = 15; break;
+            case 1: putProbability = 30; break;
+            case 2: putProbability = 10; break;
+            case 3: putProbability = 25; break;
+            case 4: putProbability = 20; break;
+            default: putProbability = 20;
+        }
+
+        bool isPut = (gen() % 100 < putProbability);
+
+        int key;
+        if (op < PHASE_LENGTH) {
+            key = gen() % 5;
+        } else if (op < PHASE_LENGTH * 2) {
+            key = gen() % 400;
+        } else if (op < PHASE_LENGTH * 3) {
+            key = (op - PHASE_LENGTH * 2) % 100;
+        } else if (op < PHASE_LENGTH * 4) {
+            int locality = (op / 800) % 5;
+            key = locality * 15 + (gen() % 15);
+        } else {
+            int r = gen() % 100;
+            if (r < 40) {
+                key = gen() % 5;
+            } else if (r < 70) {
+                key = 5 + (gen() % 45);
+            } else {
+                key = 50 + (gen() % 350);
+            }
+        }
+        ops.push_back({key, isPut});
+    }
+
     KamaCache::KLruCache<int, std::string> lru(CAPACITY);
     KamaCache::KLfuCache<int, std::string> lfu(CAPACITY);
     KamaCache::KArcCache<int, std::string> arc(CAPACITY);
     KamaCache::KLruKCache<int, std::string> lruk(CAPACITY, 500, 2);
     KamaCache::KLfuCache<int, std::string> lfuAging(CAPACITY, 10000);
 
-    std::random_device rd;
-    std::mt19937 gen(rd());
     std::array<KamaCache::KICachePolicy<int, std::string>*, 5> caches = {&lru, &lfu, &arc, &lruk, &lfuAging};
     std::vector<int> hits(5, 0);
     std::vector<int> get_operations(5, 0);
     std::vector<std::string> names = {"LRU", "LFU", "ARC", "LRU-K", "LFU-Aging"};
 
-    // 为每种缓存算法运行相同的测试
-    for (int i = 0; i < caches.size(); ++i) { 
-        // 先预热缓存，只插入少量初始数据
+    for (size_t i = 0; i < caches.size(); ++i) {
+        // 预热
         for (int key = 0; key < 30; ++key) {
-            std::string value = "init" + std::to_string(key);
-            caches[i]->put(key, value);
+            caches[i]->put(key, "init" + std::to_string(key));
         }
-        
-        // 进行多阶段测试，每个阶段有不同的访问模式
-        for (int op = 0; op < OPERATIONS; ++op) {
-            // 确定当前阶段
-            int phase = op / PHASE_LENGTH;
-            
-            // 每个阶段的读写比例不同 
-            int putProbability;
-            switch (phase) {
-                case 0: putProbability = 15; break;  // 阶段1: 热点访问，15%写入更合理
-                case 1: putProbability = 30; break;  // 阶段2: 大范围随机，写比例为30%
-                case 2: putProbability = 10; break;  // 阶段3: 顺序扫描，10%写入保持不变
-                case 3: putProbability = 25; break;  // 阶段4: 局部性随机，微调为25%
-                case 4: putProbability = 20; break;  // 阶段5: 混合访问，调整为20%
-                default: putProbability = 20;
-            }
-            
-            // 确定是读还是写操作
-            bool isPut = (gen() % 100 < putProbability);
-            
-            // 根据不同阶段选择不同的访问模式生成key - 优化后的访问范围
-            int key;
-            if (op < PHASE_LENGTH) {  // 阶段1: 热点访问 - 热点数量5，使热点更集中
-                key = gen() % 5;
-            } else if (op < PHASE_LENGTH * 2) {  // 阶段2: 大范围随机 - 范围400，更适合30大小的缓存
-                key = gen() % 400;
-            } else if (op < PHASE_LENGTH * 3) {  // 阶段3: 顺序扫描 - 保持100个键
-                key = (op - PHASE_LENGTH * 2) % 100;
-            } else if (op < PHASE_LENGTH * 4) {  // 阶段4: 局部性随机 - 优化局部性区域大小
-                // 产生5个局部区域，每个区域大小为15个键，与缓存大小20接近但略小
-                int locality = (op / 800) % 5;  // 调整为5个局部区域
-                key = locality * 15 + (gen() % 15);  // 每区域15个键
-            } else {  // 阶段5: 混合访问 - 增加热点访问比例
-                int r = gen() % 100;
-                if (r < 40) {  // 40%概率访问热点（从30%增加）
-                    key = gen() % 5;  // 5个热点键
-                } else if (r < 70) {  // 30%概率访问中等范围
-                    key = 5 + (gen() % 45);  // 缩小中等范围为50个键
-                } else {  // 30%概率访问大范围（从40%减少）
-                    key = 50 + (gen() % 350);  // 大范围也相应缩小
-                }
-            }
-            
-            if (isPut) {
-                // 执行写操作
-                std::string value = "value" + std::to_string(key) + "_p" + std::to_string(phase);
-                caches[i]->put(key, value);
+
+        // 重放操作序列
+        for (size_t opIdx = 0; opIdx < ops.size(); ++opIdx) {
+            const auto& op = ops[opIdx];
+            int phase = static_cast<int>(opIdx) / PHASE_LENGTH;
+            if (op.isPut) {
+                std::string value = "value" + std::to_string(op.key) + "_p" + std::to_string(phase);
+                caches[i]->put(op.key, value);
             } else {
-                // 执行读操作并记录命中情况
                 std::string result;
                 get_operations[i]++;
-                if (caches[i]->get(key, result)) {
+                if (caches[i]->get(op.key, result)) {
                     hits[i]++;
                 }
             }
         }
     }
 
-    printResults("工作负载剧烈变化测试", CAPACITY, get_operations, hits);
+    printResults("工作负载剧烈变化测试", CAPACITY, names, get_operations, hits);
 }
 
 int main() {
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+#endif
     testHotDataAccess();
     testLoopPattern();
     testWorkloadShift();


### PR DESCRIPTION
内存安全:
- KLfuCache::freqToFreqList_ 从裸指针改为 std::unique_ptr，修复内存泄漏
- KHashLruCaches::get() 移除危险的 memset 调用

线程安全:
- KArcLfuPart::contain() 添加 mutex 保护
- KLruKCache 添加 kMutex_ 保护 get/put 整体原子性

接口优化:
- 所有缓存接口参数从按值传递改为 const 引用传递
- minFreq_ 哨兵值从 INT8_MAX 改为 std::numeric_limits<int>::max()
- KLruKCache 构造函数修复成员初始化顺序警告

Benchmark 改进:
- 使用固定种子预生成操作序列，所有策略重放相同序列保证公平性
- printResults() 显式传入算法名称向量